### PR TITLE
feat: adding titlePath for mocha 4 compat

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,11 @@ var Reporter = function(baseReporterDecorator, formatError, reportSlowerThan, pl
                 return result.suite.concat(result.description).join(' ');
 
             },
+            titlePath: function() {
+
+                return [result.suite, result.description];
+
+            },
             duration: result.time,
             slow: function() {
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "devDependencies": {
     "eslint": "^1.10.1",
-    "mocha": "^2.3.4"
+    "mocha": "^4.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Mocha 4 introduces a new method to report the full path of the test `titlePath`. This PR adds the missing method for compatibility with mocha 4.